### PR TITLE
add a function of automatable add KE data-source-table

### DIFF
--- a/mlsql-ke/src/main/java/tech/mlsql/plugins/ke/ets/KEAutoModel.scala
+++ b/mlsql-ke/src/main/java/tech/mlsql/plugins/ke/ets/KEAutoModel.scala
@@ -2,7 +2,10 @@ package tech.mlsql.plugins.ke.ets
 
 import com.alibaba.fastjson.JSONObject
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import streaming.dsl.mmlib.algs.param.WowParams
 import streaming.dsl.{ConnectMeta, DBMappingKey}
 import tech.mlsql.common.utils.log.Logging
@@ -19,6 +22,8 @@ class KEAutoModel(override val uid: String) extends KEAPISchedule with WowParams
     if (params.contains("sqls")) {
       val sqls = params("sqls").split("\\;")
       jsonObj.put("sqls", sqls)
+    }else{
+      throw new Exception("The sqls parameter is required")
     }
     if (params.contains("with_segment")) {
       jsonObj.put("with_segment", params("with_segment").toBoolean)
@@ -26,10 +31,80 @@ class KEAutoModel(override val uid: String) extends KEAPISchedule with WowParams
     if (params.contains("with_model_online")) {
       jsonObj.put("with_model_online", params("with_model_online").toBoolean)
     }
+
+    if(params.getOrElse("auto_add_tables","false").toBoolean){
+      val spark = df.sparkSession
+      val lp = df.queryExecution.analyzed
+      val dataSources1 = getSourceRelation(lp)
+      //collect dataSources from sqls
+      val dataSources2 = parserTablesFromSqls(df.sparkSession,params("sqls").split("\\;"))
+
+      var dataSources3:Array[String] = Array()
+      if (params.get("tables").nonEmpty){
+        dataSources3 = params("tables").split(",")
+      }
+      val dataSources = (dataSources1.keySet ++ dataSources2.keySet ++ dataSources3.toSet).toArray
+      if(dataSources.nonEmpty){
+        var url1 = new String
+        ConnectMeta.presentThenCall(DBMappingKey("ke", connectName), options => {
+          url1 = "http://" + options("host") + ":" + options("port") + "/kylin/api/tables"
+        })
+
+        val jsonObj1 = new JSONObject
+        jsonObj1.put("project",split(1))
+        jsonObj1.put("tables",dataSources)
+        jsonObj1.put("need_sampling",false)
+
+        sendPostAPI(df, Map(("Accept"->"application/vnd.apache.kylin-v4-public+json")), jsonObj1, url1, connectName)
+      }
+    }
+
     var url = new String
     ConnectMeta.presentThenCall(DBMappingKey("ke", connectName), options => {
       url = "http://" + options("host") + ":" + options("port") + "/kylin/api/models/model_suggestion"
     })
-    sendPostAPI(df, params, jsonObj, url, connectName)
+    sendPostAPI(df, Map(("Accept"->"application/vnd.apache.kylin-v4-public+json")), jsonObj, url, connectName)
   }
+
+  def parserTablesFromSqls(spark:SparkSession, sqls:Array[String]): Map[String,Map[String, String]] ={
+    var sourcesMaps = sqls.map(parserTablesFromSql(spark,_))
+    var sources = sourcesMaps.reduce((x,y)=>x ++ y)
+    sources
+  }
+
+  def parserTablesFromSql(spark:SparkSession, sql:String): Map[String,Map[String, String]] ={
+    val lp = spark.sql(sql).queryExecution.analyzed
+    val dataSources = getSourceRelation(lp)
+    return dataSources
+  }
+
+
+  // 表可能会来自不同类型的数据库，不同名称的数据库。但是目前KE(4.3.3)只支持添加hive数据源，所以目前只考虑hive数据源
+  def getSourceRelation(lp: LogicalPlan): Map[String,Map[String, String]] ={
+//    println(lp.toString())
+    var sources:Map[String,Map[String, String]] = Map()
+    lp transform {
+      case lr@HiveTableRelation(catalogTable, _, _) =>
+        var dbName = "default"
+        if(lr.tableMeta.identifier.database.nonEmpty){
+          dbName = lr.tableMeta.identifier.database.get
+        }
+        val dbtableName = dbName + "." + lr.tableMeta.identifier.table
+        sources += (dbtableName -> Map())
+        lr
+      case lr@LogicalRelation(hfr@HadoopFsRelation(_,_,_,_,_,_), _,catalogTable@Some(x),_) =>
+        val ct = catalogTable.get
+        if(ct.tableType.name.toString == "MANAGED"){
+          var dbName = "default"
+          if(ct.identifier.database.nonEmpty){
+            dbName = ct.identifier.database.get
+          }
+          val dbtableName = dbName + "." + ct.identifier.table
+          sources += (dbtableName -> Map())
+        }
+        lr
+    }
+    sources
+  }
+
 }


### PR DESCRIPTION
add a function that can automatable parse tables from DF.

It supports 4 ways of use：

Mode1: collect the hive table by parsing SQL from sqls parameter 
Mode2: Mode1 + collect the hive table  from DF
Mode3: Mode1 + tables parameter
Mode4: Mode2 + tables parameter

```connect ke where username="ADMIN" 
and password="KYLIN" 
and host="localhost"
and port="7070"
as ff_ke_conn;

set model_sql = '''

select sum(v_revenue) as revenue
from ssb.p_lineorder
left join ssb.dates on lo_orderdate = d_datekey
where d_year = 1993
and lo_discount between 1 and 3
and lo_quantity < 25;select sum(v_revenue) as revenue
from ssb.p_lineorder
left join ssb.dates on lo_orderdate = d_datekey
where d_yearmonthnum = 199401
and lo_discount between 4 and 6
and lo_quantity between 26 and 35

''';

-- -- 支持三种方式 自动添加数据源！

-- -- 第一种方式：
-- -- 解析sqls参数中的sql，从中解析出用到的hive数据源！
-- -- 会解析 sqls 参数中所用到的 所有的hive表，并自动添加到KE数据源。
-- run command as KeAutoModel.`ff_ke_conn.test_ff` where
-- and sqls='''${model_sql}''' and auto_add_tables="true" as newtable1;
-- select * from newtable1 as output;


load hive.`ssb.dates`  as dates;
load hive.`ssb.p_lineorder` as p_lineorder;

select sum(v_revenue) as revenue
from p_lineorder
left join dates on lo_orderdate = d_datekey
where d_year = 1993
and lo_discount between 1 and 3
and lo_quantity < 25  as tmpDF;

-- -- 第二种方式：
-- -- 方式1 + DF 
-- 在做一些探索分析时如果想要把感兴趣的hive sql 使用ke加速，则可以直接使用如下方式。
-- 下面在创建模型是则可以直接自动添加 tmpDF 中用到的数据源（默认不添加）,并且
-- 同时会解析 sqls 参数中所用到的 所有的hive表，并自动添加到KE数据源。
-- 当然也可以使用 方式1 - 不使用tmpDF 而是用command 代替，但是 sqls参数是必须的！
-- 目前只支持 hive表，因为KE目前只支持添加hive数据源。
-- 参数: auto_add_tables 用来控制是否从df中获取数据源并自动添加到KE
run tmpDF as KeAutoModel.`ff_ke_conn.test_ff` where
and sqls='''${model_sql}''' and auto_add_tables="true" as newtable1;
select * from newtable1 as output;
```

-- -- 第三种方式：
-- -- 方式1 + 直接设置数据源tables列表,使用 tables 参数
-- tables 参数：指定ke添加的数据源表名，多个表名使用逗号隔开
run command as KeAutoModel.`ff_ke_conn.test_ff` where
and sqls='''${model_sql}''' 
and auto_add_tables="true"  
and tables="ssb.p_lineorder,ssb.dates" 
as newtable1;
select * from newtable1 as output;
```

