### PR TITLE
Fix Assert ET returns an empty dataframe in the correct case

### DIFF
--- a/mlsql-assert/src/main/java/tech/mlsql/plugins/assert/ets/Assert.scala
+++ b/mlsql-assert/src/main/java/tech/mlsql/plugins/assert/ets/Assert.scala
@@ -37,10 +37,10 @@ class Assert(override val uid: String) extends SQLAlg
     val tableName = args.head
     val assertString = args.last
     val assertRes = evaluate(tableName, args.drop(1).dropRight(1).mkString(" "))
-    if (assertRes.filter(_ == false).length != 0) {
+    if (assertRes.contains(false)) {
       throw new RuntimeException(assertString)
     }
-    df
+    df.sparkSession.emptyDataFrame
   }
 
   def evaluate(tableName: String, str: String, options: Map[String, String] = Map()) = {


### PR DESCRIPTION
When we use the Assert plugin, if we get the expected result, it will return a dataSet. As follows:
+------+
| a          |
+------+
| 1          |
+------+
But if it is the expected result, it is more appropriate for us to return an empty dataFrame.